### PR TITLE
breaking: successful exit on 0 image count

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -160,7 +160,7 @@ if [ "$BYPASS_CHECK" = false ]; then
   if [ "$image_count_within_threshold" -le 1 ]; then
     echo "WARNING: Safety check failed"
     echo "  • No images found newer than $DAYS day(s)"
-    exit 1
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
Changes the exit code to 0, if there are 0 images newer than the set threshold days. Just to avoid errors for something that seems perfectly fine in my opinion:

<img width="709" height="489" alt="image" src="https://github.com/user-attachments/assets/088714af-d73c-411e-a017-0707b4394bcf" />


If a breaking release is not desirable, then another option is to change this PR to have an extra flag toggling the behaviour of the exit on 0 images.